### PR TITLE
#2 - set registers myself, instead relaying on bios

### DIFF
--- a/boot.asm
+++ b/boot.asm
@@ -1,7 +1,17 @@
-ORG 0x7c00
+ORG 0
 BITS 16
 
+jmp  0x7c0:start
 start:
+    cli ;Clear interrupts
+    mov ax, 0x7c0
+    mov ds, ax
+    mov es, ax
+    mov ax, 0x00
+    mov ss, ax
+    mov sp, 0x7c00
+    sti ;Enable interrupts
+    
     mov si, message ;move address of the message to si register
     call print ;call print subroutin
     jmp $


### PR DESCRIPTION
We really don't know what the registers could be when the bios loads the program, so it better to set it as it increases chances to be successfully booted on a real machine.